### PR TITLE
ACF compatability fix for len() and structures

### DIFF
--- a/views/home/routeTable.cfm
+++ b/views/home/routeTable.cfm
@@ -45,9 +45,9 @@
 				</cfif>
 
 				<cfif isStruct( thisRoute.action )>
-					<strong>Action:</strong> #thisRoute.action.toString()#
-				<cfelseif thisRoute.action.len() ?: 0>
 					<strong>Action:</strong> #serializeJSON( thisRoute.action )#
+				<cfelseif thisRoute.action.len() ?: 0>
+					<strong>Action:</strong> #thisRoute.action.toString()#
 				</cfif>
 
 				<cfif thisRoute.event.len() ?: 0>

--- a/views/home/routeTable.cfm
+++ b/views/home/routeTable.cfm
@@ -44,9 +44,9 @@
 					<strong>Handler:</strong> #thisRoute.handler#<br>
 				</cfif>
 
-				<cfif thisRoute.action.len() ?: 0>
+				<cfif isStruct( thisRoute.action )>
 					<strong>Action:</strong> #thisRoute.action.toString()#
-				<cfelseif isStruct( thisRoute.action )>
+				<cfelseif thisRoute.action.len() ?: 0>
 					<strong>Action:</strong> #serializeJSON( thisRoute.action )#
 				</cfif>
 


### PR DESCRIPTION
ACF doesn't have support for running len() on structures.  In order for the code to work in ACF, we need to check if thisRoute.action is a structure first before running len() on it.